### PR TITLE
linux-yocto-edison.bbappend: Add NFLX-2019-001 series of patches

### DIFF
--- a/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison.bbappend
+++ b/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison.bbappend
@@ -1,5 +1,13 @@
 inherit kernel-resin
 
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0002-NFLX-2019-001-SACK-Panic.patch \
+            file://0004-NFLX-2019-001-SACK-Slowness.patch \
+            file://0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
+            file://0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch \
+            "
+
 # enable USB hub kernel module as requested by customer
 RESIN_CONFIGS_append = " smsc95xx"
 RESIN_CONFIGS[smsc95xx] = "CONFIG_USB_NET_SMSC95XX=m"

--- a/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0002-NFLX-2019-001-SACK-Panic.patch
+++ b/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0002-NFLX-2019-001-SACK-Panic.patch
@@ -1,0 +1,168 @@
+
+Date: Sat,  8 Jun 2019 10:38:05 -0700
+Subject: [PATCH net 1/4] tcp: limit payload size of sacked skbs
+From: Eric Dumazet <edumazet@google.com>
+
+Jonathan Looney reported that TCP can trigger the following crash
+in tcp_shifted_skb() :
+
+BUG_ON(tcp_skb_pcount(skb) < pcount);
+
+This can happen if the remote peer has advertized the smallest
+MSS that linux TCP accepts : 48
+
+An skb can hold 17 fragments, and each fragment can hold 32KB
+on x86, or 64KB on PowerPC.
+
+This means that the 16bit witdh of TCP_SKB_CB(skb)->tcp_gso_segs
+can overflow.
+
+Note that tcp_sendmsg() builds skbs with less than 64KB
+of payload, so this problem needs SACK to be enabled.
+SACK blocks allow TCP to coalesce multiple skbs in the retransmit
+queue, thus filling the 17 fragments to maximal capacity.
+
+Fixes: 832d11c5cd07 ("tcp: Try to restore large SKBs while SACK processing")
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ include/linux/tcp.h   |  4 ++++
+ include/net/tcp.h     |  2 ++
+ net/ipv4/tcp.c        |  1 +
+ net/ipv4/tcp_input.c  | 28 +++++++++++++++++++++-------
+ net/ipv4/tcp_output.c |  6 +++---
+ 5 files changed, 31 insertions(+), 10 deletions(-)
+
+diff --git a/include/linux/tcp.h b/include/linux/tcp.h
+index ca4a636..1f185c3 100644
+--- a/include/linux/tcp.h
++++ b/include/linux/tcp.h
+@@ -460,4 +460,8 @@ static inline u16 tcp_mss_clamp(const struct tcp_sock *tp, u16 mss)
+ 
+ 	return (user_mss && user_mss < mss) ? user_mss : mss;
+ }
++
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from, int pcount,
++		  int shiftlen);
++
+ #endif	/* _LINUX_TCP_H */
+diff --git a/include/net/tcp.h b/include/net/tcp.h
+index 6da880d..9b4b81d 100644
+--- a/include/net/tcp.h
++++ b/include/net/tcp.h
+@@ -54,6 +54,8 @@ void tcp_time_wait(struct sock *sk, int state, int timeo);
+ 
+ #define MAX_TCP_HEADER	(128 + MAX_HEADER)
+ #define MAX_TCP_OPTION_SPACE 40
++#define TCP_MIN_SND_MSS		48
++#define TCP_MIN_GSO_SIZE	(TCP_MIN_SND_MSS - MAX_TCP_OPTION_SPACE)
+ 
+ /*
+  * Never offer a window over 32767 without using window scaling. Some
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index 2eb91b9..8f1c0e7 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -3582,6 +3582,7 @@ void __init tcp_init(void)
+ 	unsigned long limit;
+ 	unsigned int i;
+ 
++	BUILD_BUG_ON(TCP_MIN_SND_MSS <= MAX_TCP_OPTION_SPACE);
+ 	BUILD_BUG_ON(sizeof(struct tcp_skb_cb) >
+ 		     FIELD_SIZEOF(struct sk_buff, cb));
+ 
+diff --git a/net/ipv4/tcp_input.c b/net/ipv4/tcp_input.c
+index 0228f49..f1e4788 100644
+--- a/net/ipv4/tcp_input.c
++++ b/net/ipv4/tcp_input.c
+@@ -1283,7 +1283,7 @@ static bool tcp_shifted_skb(struct sock *sk, struct sk_buff *prev,
+ 	TCP_SKB_CB(skb)->seq += shifted;
+ 
+ 	tcp_skb_pcount_add(prev, pcount);
+-	BUG_ON(tcp_skb_pcount(skb) < pcount);
++	WARN_ON_ONCE(tcp_skb_pcount(skb) < pcount);
+ 	tcp_skb_pcount_add(skb, -pcount);
+ 
+ 	/* When we're adding to gso_segs == 1, gso_size will be zero,
+@@ -1349,6 +1349,21 @@ static int skb_can_shift(const struct sk_buff *skb)
+ 	return !skb_headlen(skb) && skb_is_nonlinear(skb);
+ }
+ 
++int tcp_skb_shift(struct sk_buff *to, struct sk_buff *from,
++		  int pcount, int shiftlen)
++{
++	/* TCP min gso_size is 8 bytes (TCP_MIN_GSO_SIZE)
++	 * Since TCP_SKB_CB(skb)->tcp_gso_segs is 16 bits, we need
++	 * to make sure not storing more than 65535 * 8 bytes per skb,
++	 * even if current MSS is bigger.
++	 */
++	if (unlikely(to->len + shiftlen >= 65535 * TCP_MIN_GSO_SIZE))
++		return 0;
++	if (unlikely(tcp_skb_pcount(to) + pcount > 65535))
++		return 0;
++	return skb_shift(to, from, shiftlen);
++}
++
+ /* Try collapsing SACK blocks spanning across multiple skbs to a single
+  * skb.
+  */
+@@ -1457,7 +1472,7 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 	if (!after(TCP_SKB_CB(skb)->seq + len, tp->snd_una))
+ 		goto fallback;
+ 
+-	if (!skb_shift(prev, skb, len))
++	if (!tcp_skb_shift(prev, skb, pcount, len))
+ 		goto fallback;
+ 	if (!tcp_shifted_skb(sk, prev, skb, state, pcount, len, mss, dup_sack))
+ 		goto out;
+@@ -1475,11 +1490,10 @@ static struct sk_buff *tcp_shift_skb_data(struct sock *sk, struct sk_buff *skb,
+ 		goto out;
+ 
+ 	len = skb->len;
+-	if (skb_shift(prev, skb, len)) {
+-		pcount += tcp_skb_pcount(skb);
+-		tcp_shifted_skb(sk, prev, skb, state, tcp_skb_pcount(skb),
+-				len, mss, 0);
+-	}
++	pcount = tcp_skb_pcount(skb);
++	if (tcp_skb_shift(prev, skb, pcount, len))
++		tcp_shifted_skb(sk, prev, skb, state, pcount,
++				len, mss, 0);
+ 
+ out:
+ 	return prev;
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 871c7e2..780f6e4 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1479,8 +1479,8 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < 48)
+-		mss_now = 48;
++	if (mss_now < TCP_MIN_SND_MSS)
++		mss_now = TCP_MIN_SND_MSS;
+ 	return mss_now;
+ }
+ 
+@@ -2741,7 +2741,7 @@ static bool tcp_collapse_retrans(struct sock *sk, struct sk_buff *skb)
+ 		if (next_skb_size <= skb_availroom(skb))
+ 			skb_copy_bits(next_skb, 0, skb_put(skb, next_skb_size),
+ 				      next_skb_size);
+-		else if (!skb_shift(skb, next_skb, next_skb_size))
++		else if (!tcp_skb_shift(skb, next_skb, 1, next_skb_size))
+ 			return false;
+ 	}
+ 	tcp_highest_sack_replace(sk, next_skb, skb);
+-- 
+2.7.4
+

--- a/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0004-NFLX-2019-001-SACK-Slowness.patch
+++ b/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0004-NFLX-2019-001-SACK-Slowness.patch
@@ -1,0 +1,77 @@
+Date: Sat,  8 Jun 2019 10:38:06 -0700
+Subject: [PATCH net 2/4] tcp: tcp_fragment() should apply sane memory limits
+From: Eric Dumazet <edumazet@google.com>
+
+Jonathan Looney reported that a malicious peer can force a sender
+to fragment its retransmit queue into tiny skbs, inflating memory
+usage and/or overflow 32bit counters.
+
+TCP allows an application to queue up to sk_sndbuf bytes,
+so we need to give some allowance for non malicious splitting
+of retransmit queue.
+
+A new SNMP counter is added to monitor how many times TCP
+did not allow to split an skb if the allowance was exceeded.
+
+Note that this counter might increase in the case applications
+use SO_SNDBUF socket option to lower sk_sndbuf.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Looney <jtl@netflix.com>
+Acked-by: Neal Cardwell <ncardwell@google.com>
+Acked-by: Yuchung Cheng <ycheng@google.com>
+Reviewed-by: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ include/uapi/linux/snmp.h | 1 +
+ net/ipv4/proc.c           | 1 +
+ net/ipv4/tcp_output.c     | 5 +++++
+ 3 files changed, 7 insertions(+)
+
+diff --git a/include/uapi/linux/snmp.h b/include/uapi/linux/snmp.h
+index f5d753e..bf31965 100644
+--- a/include/uapi/linux/snmp.h
++++ b/include/uapi/linux/snmp.h
+@@ -278,6 +278,7 @@ enum
+ 	LINUX_MIB_TCPKEEPALIVE,			/* TCPKeepAlive */
+ 	LINUX_MIB_TCPMTUPFAIL,			/* TCPMTUPFail */
+ 	LINUX_MIB_TCPMTUPSUCCESS,		/* TCPMTUPSuccess */
++	LINUX_MIB_TCPWQUEUETOOBIG,		/* TCPWqueueTooBig */
+ 	__LINUX_MIB_MAX
+ };
+ 
+diff --git a/net/ipv4/proc.c b/net/ipv4/proc.c
+index 3fbf688..88aaf14 100644
+--- a/net/ipv4/proc.c
++++ b/net/ipv4/proc.c
+@@ -299,6 +299,7 @@ static const struct snmp_mib snmp4_net_list[] = {
+ 	SNMP_MIB_ITEM("TCPKeepAlive", LINUX_MIB_TCPKEEPALIVE),
+ 	SNMP_MIB_ITEM("TCPMTUPFail", LINUX_MIB_TCPMTUPFAIL),
+ 	SNMP_MIB_ITEM("TCPMTUPSuccess", LINUX_MIB_TCPMTUPSUCCESS),
++	SNMP_MIB_ITEM("TCPWqueueTooBig", LINUX_MIB_TCPWQUEUETOOBIG),
+ 	SNMP_MIB_SENTINEL
+ };
+ 
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index def09d1..36d1945 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1274,6 +1274,11 @@ int tcp_fragment(struct sock *sk, struct sk_buff *skb, u32 len,
+ 	if (nsize < 0)
+ 		nsize = 0;
+ 
++	if (unlikely((sk->sk_wmem_queued >> 1) > sk->sk_sndbuf)) {
++		NET_INC_STATS(sock_net(sk), LINUX_MIB_TCPWQUEUETOOBIG);
++		return -ENOMEM;
++	}
++
+ 	if (skb_unclone(skb, gfp))
+ 		return -ENOMEM;
+ 
+-- 
+2.7.4
+

--- a/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch
+++ b/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0005-NFLX-2019-001-Resour-Consump-Low-MSS.patch
@@ -1,0 +1,134 @@
+Date: Sat,  8 Jun 2019 10:38:07 -0700
+Subject: [PATCH net 3/4] tcp: add tcp_min_snd_mss sysctl
+From: Eric Dumazet <edumazet@google.com>
+
+Some TCP peers announce a very small MSS option in their SYN and/or
+SYN/ACK messages.
+
+This forces the stack to send packets with a very high network/cpu
+overhead.
+
+Linux has enforced a minimal value of 48. Since this value includes
+the size of TCP options, and that the options can consume up to 40
+bytes, this means that each segment can include only 8 bytes of payload.
+
+In some cases, it can be useful to increase the minimal value
+to a saner value.
+
+We still let the default to 48 (TCP_MIN_SND_MSS), for compatibility
+reasons.
+
+Note that TCP_MAXSEG socket option enforces a minimal value
+of (TCP_MIN_MSS). David Miller increased this minimal value
+in commit c39508d6f118 ("tcp: Make TCP_MAXSEG minimum more correct.")
+from 64 to 88.
+
+We might in the future merge TCP_MIN_SND_MSS and TCP_MIN_MSS.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Suggested-by: Jonathan Looney <jtl@netflix.com>
+Cc: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+Cc: Jonathan Lemon <jonathan.lemon@gmail.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ Documentation/networking/ip-sysctl.txt |  8 ++++++++
+ include/net/netns/ipv4.h               |  1 +
+ net/ipv4/sysctl_net_ipv4.c             | 11 +++++++++++
+ net/ipv4/tcp_ipv4.c                    |  1 +
+ net/ipv4/tcp_output.c                  |  3 +--
+ 5 files changed, 22 insertions(+), 2 deletions(-)
+
+diff --git a/Documentation/networking/ip-sysctl.txt b/Documentation/networking/ip-sysctl.txt
+index 14fe93049d28e965d7349b03c5c8782c3d386e7d..8cafd044eec0a228576d85e32729f34413abcd43 100644
+--- a/Documentation/networking/ip-sysctl.txt
++++ b/Documentation/networking/ip-sysctl.txt
+@@ -255,6 +255,14 @@ tcp_base_mss - INTEGER
+ 	Path MTU discovery (MTU probing).  If MTU probing is enabled,
+ 	this is the initial MSS used by the connection.
+ 
++tcp_min_snd_mss - INTEGER
++	TCP SYN and SYNACK messages usually advertise an ADVMSS option,
++	as described in RFC 1122 and RFC 6691.
++	If this ADVMSS option is smaller than tcp_min_snd_mss,
++	it is silently capped to tcp_min_snd_mss.
++
++	Default : 48 (at least 8 bytes of payload per segment)
++
+ tcp_congestion_control - STRING
+ 	Set the congestion control algorithm to be used for new
+ 	connections. The algorithm "reno" is always available, but
+diff --git a/include/net/netns/ipv4.h b/include/net/netns/ipv4.h
+index 7698460a3dd1e5070e12d406b3ee58834688cdc9..623cfbb7b8dcbb2a6d8325ec010aff78bbdf8839 100644
+--- a/include/net/netns/ipv4.h
++++ b/include/net/netns/ipv4.h
+@@ -117,6 +117,7 @@ struct netns_ipv4 {
+ #endif
+ 	int sysctl_tcp_mtu_probing;
+ 	int sysctl_tcp_base_mss;
++	int sysctl_tcp_min_snd_mss;
+ 	int sysctl_tcp_probe_threshold;
+ 	u32 sysctl_tcp_probe_interval;
+ 
+diff --git a/net/ipv4/sysctl_net_ipv4.c b/net/ipv4/sysctl_net_ipv4.c
+index 875867b64d6a6597bf4fcd3498ed55741cbe33f7..16577af90337af87856b4c2157823c5d90df035b 100644
+--- a/net/ipv4/sysctl_net_ipv4.c
++++ b/net/ipv4/sysctl_net_ipv4.c
+@@ -39,6 +39,8 @@ static int ip_local_port_range_min[] = { 1, 1 };
+ static int ip_local_port_range_max[] = { 65535, 65535 };
+ static int tcp_adv_win_scale_min = -31;
+ static int tcp_adv_win_scale_max = 31;
++static int tcp_min_snd_mss_min = TCP_MIN_SND_MSS;
++static int tcp_min_snd_mss_max = 65535;
+ static int ip_privileged_port_min;
+ static int ip_privileged_port_max = 65535;
+ static int ip_ttl_min = 1;
+@@ -757,6 +759,15 @@ static struct ctl_table ipv4_net_table[] = {
+ 		.mode		= 0644,
+ 		.proc_handler	= proc_dointvec,
+ 	},
++	{
++		.procname	= "tcp_min_snd_mss",
++		.data		= &init_net.ipv4.sysctl_tcp_min_snd_mss,
++		.maxlen		= sizeof(int),
++		.mode		= 0644,
++		.proc_handler	= proc_dointvec_minmax,
++		.extra1		= &tcp_min_snd_mss_min,
++		.extra2		= &tcp_min_snd_mss_max,
++	},
+ 	{
+ 		.procname	= "tcp_probe_threshold",
+ 		.data		= &init_net.ipv4.sysctl_tcp_probe_threshold,
+diff --git a/net/ipv4/tcp_ipv4.c b/net/ipv4/tcp_ipv4.c
+index bc86f9735f4577d50d94f42b10edb6ba95bb7a05..cfa81190a1b1af30d05f4f6cd84c05b025a6afeb 100644
+--- a/net/ipv4/tcp_ipv4.c
++++ b/net/ipv4/tcp_ipv4.c
+@@ -2628,6 +2628,7 @@ static int __net_init tcp_sk_init(struct net *net)
+ 	net->ipv4.sysctl_tcp_ecn_fallback = 1;
+ 
+ 	net->ipv4.sysctl_tcp_base_mss = TCP_BASE_MSS;
++	net->ipv4.sysctl_tcp_min_snd_mss = TCP_MIN_SND_MSS;
+ 	net->ipv4.sysctl_tcp_probe_threshold = TCP_PROBE_THRESHOLD;
+ 	net->ipv4.sysctl_tcp_probe_interval = TCP_PROBE_INTERVAL;
+ 
+diff --git a/net/ipv4/tcp_output.c b/net/ipv4/tcp_output.c
+index 1bb1c46b4abad100622d3f101a0a3ca0a6c8e881..00c01a01b547ec67c971dc25a74c9258563cf871 100644
+--- a/net/ipv4/tcp_output.c
++++ b/net/ipv4/tcp_output.c
+@@ -1459,8 +1459,7 @@ static inline int __tcp_mtu_to_mss(struct sock *sk, int pmtu)
+ 	mss_now -= icsk->icsk_ext_hdr_len;
+ 
+ 	/* Then reserve room for full set of TCP options and 8 bytes of data */
+-	if (mss_now < TCP_MIN_SND_MSS)
+-		mss_now = TCP_MIN_SND_MSS;
++	mss_now = max(mss_now, sock_net(sk)->ipv4.sysctl_tcp_min_snd_mss);
+ 	return mss_now;
+ }
+ 
+-- 
+2.22.0.rc2.383.gf4fbbf30c2-goog
+

--- a/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch
+++ b/layers/meta-balena-edison/recipes-kernel/linux/linux-yocto-edison/0006-NFLX-2019-001-Resour-Consump-Low-MSS.patch
@@ -1,0 +1,39 @@
+Date: Sat,  8 Jun 2019 10:38:08 -0700
+Subject: [PATCH net 4/4] tcp: enforce tcp_min_snd_mss in tcp_mtu_probing()
+From: Eric Dumazet <edumazet@google.com>
+
+If mtu probing is enabled tcp_mtu_probing() could very well end up
+with a too small MSS.
+
+Use the new sysctl tcp_min_snd_mss to make sure MSS search
+is performed in an acceptable range.
+
+Signed-off-by: Eric Dumazet <edumazet@google.com>
+Reported-by: Jonathan Lemon <jonathan.lemon@gmail.com>
+Cc: Jonathan Looney <jtl@netflix.com>
+Cc: Neal Cardwell <ncardwell@google.com>
+Cc: Yuchung Cheng <ycheng@google.com>
+Cc: Tyler Hicks <tyhicks@canonical.com>
+Cc: Bruce Curtis <brucec@netflix.com>
+
+Upstream-Status: Inappropriate [not author]
+Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>
+---
+ net/ipv4/tcp_timer.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/net/ipv4/tcp_timer.c b/net/ipv4/tcp_timer.c
+index c721140..5520576 100644
+--- a/net/ipv4/tcp_timer.c
++++ b/net/ipv4/tcp_timer.c
+@@ -137,6 +137,7 @@ static void tcp_mtu_probing(struct inet_connection_sock *icsk, struct sock *sk)
+ 		mss = tcp_mtu_to_mss(sk, icsk->icsk_mtup.search_low) >> 1;
+ 		mss = min(net->ipv4.sysctl_tcp_base_mss, mss);
+ 		mss = max(mss, 68 - tcp_sk(sk)->tcp_header_len);
++		mss = max(mss, net->ipv4.sysctl_tcp_min_snd_mss);
+ 		icsk->icsk_mtup.search_low = tcp_mss_to_mtu(sk, mss);
+ 	}
+ 	tcp_sync_mss(sk, icsk->icsk_pmtu_cookie);
+-- 
+2.7.4
+


### PR DESCRIPTION
Add patches for multiple TCP-based remote denial
of service vulnerabilities identified by Netflix.
Patch source:
https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-001.md

Changelog-entry: Patches for TCP-based remote denial of service vulnerabilities
Signed-off-by: Vicentiu Galanopulo <vicentiu@balena.io>