### PR TITLE
edison.coffee: Set private to false for the public device types

### DIFF
--- a/edison.coffee
+++ b/edison.coffee
@@ -50,6 +50,7 @@ module.exports =
 	name: 'Intel Edison'
 	arch: 'i386'
 	state: 'released'
+	private: false
 
 	gettingStartedLink: 'http://docs.resin.io/#/pages/installing/gettingStarted-Edison.md'
 


### PR DESCRIPTION
Changelog-entry: Set private to false in .coffee files for the public device types

Signed-off-by: Florin Sarbu <florin@balena.io>