### PR TITLE
conf: disable user-ns for edison

### DIFF
--- a/layers/meta-balena-edison/conf/layer.conf
+++ b/layers/meta-balena-edison/conf/layer.conf
@@ -11,3 +11,6 @@ DISTRO_FEATURES_append_edison = " bluez5"
 
 LAYERSERIES_COMPAT_edison = "warrior"
 LAYERSERIES_COMPAT_balena-edison = "warrior"
+
+# Leave user namespacing disabled at runtime to match upstream
+DISTRO_FEATURES_append_edison = " disable-user-ns"


### PR DESCRIPTION
Disable user namespacing for Intel Edison to match upstream behavior.

Change-type: patch
Signed-off-by: Joseph Kogut <joseph@balena.io>