### PR TITLE
edison: set as discontinued

### DIFF
--- a/edison.coffee
+++ b/edison.coffee
@@ -49,7 +49,7 @@ module.exports =
 	aliases: [ 'edison' ]
 	name: 'Intel Edison'
 	arch: 'i386'
-	state: 'released'
+	state: 'discontinued'
 	private: false
 
 	gettingStartedLink: 'http://docs.resin.io/#/pages/installing/gettingStarted-Edison.md'


### PR DESCRIPTION
The intel Edison was discontinued by the vendor on June 19, 2017.

Change-type: patch
Signed-off-by: Alex Gonzalez <alexg@balena.io>